### PR TITLE
Add data source credit overlay

### DIFF
--- a/src/pages/index.vue
+++ b/src/pages/index.vue
@@ -4,7 +4,13 @@
       <point-land class="wrapper" />
     </client-only>
     <help-btn />
-    <v-overlay :value="$store.state.loading"> <v-progress-circular indeterminate size="64"></v-progress-circular></v-overlay>
+    <div class="source-info">
+      This pointcloud source is from
+      <a href="https://3dview.tokyo-digitaltwin.metro.tokyo.lg.jp/" target="_blank" rel="noopener noreferrer">City of Tokyo</a>
+    </div>
+    <v-overlay :value="$store.state.loading">
+      <v-progress-circular indeterminate size="64"></v-progress-circular>
+    </v-overlay>
   </div>
 </template>
 
@@ -13,3 +19,14 @@ export default {}
 </script>
 
 <style src="~/assets/style/index.css" />
+<style>
+.source-info {
+  position: fixed;
+  bottom: 0.5em;
+  left: 0.5em;
+  font-size: 0.75rem;
+  color: #eee;
+  opacity: 0.7;
+  z-index: 2;
+}
+</style>


### PR DESCRIPTION
## Summary
- add a small credit at bottom-left showing pointcloud source link

## Testing
- `yarn lint` *(fails: package missing in lockfile)*

------
https://chatgpt.com/codex/tasks/task_e_6844d51f1cec8327936b8857b3560cc0