### PR TITLE
Add Tokyo landmark shortcut buttons

### DIFF
--- a/src/components/LandmarkBtns.vue
+++ b/src/components/LandmarkBtns.vue
@@ -1,0 +1,51 @@
+<template>
+  <div id="landmark-btns">
+    <v-btn
+      v-for="(lm, i) in landmarks"
+      :key="lm.name"
+      small
+      class="ma-1"
+      @click="go(i)"
+    >
+      {{ i + 1 }}
+    </v-btn>
+  </div>
+</template>
+
+<script>
+import landmarks from '~/data/landmarks'
+
+export default {
+  data() {
+    return { landmarks }
+  },
+  mounted() {
+    window.addEventListener('keydown', this.shortcut)
+  },
+  beforeDestroy() {
+    window.removeEventListener('keydown', this.shortcut)
+  },
+  methods: {
+    go(i) {
+      const lm = this.landmarks[i]
+      if (!this.$root.$layerspace) return
+      const controls = this.$root.$layerspace.space.controls
+      const p = lm.position
+      controls.setLookAt(p[0] + 2000, p[1] + 2000, p[2] + 500, p[0], p[1], p[2], true)
+    },
+    shortcut(e) {
+      const keyMap = { F1: 0, F2: 1, F3: 2, F4: 3, F5: 4 }
+      if (keyMap[e.code] !== undefined) this.go(keyMap[e.code])
+    },
+  },
+}
+</script>
+
+<style>
+#landmark-btns {
+  position: fixed;
+  top: 1em;
+  right: 1em;
+  z-index: 10;
+}
+</style>

--- a/src/composables/usePointland.js
+++ b/src/composables/usePointland.js
@@ -1,4 +1,5 @@
 import LayerSpace from 'layerspace'
+import landmarks from '~/data/landmarks'
 
 const POSITION = [10, 130, 50]
 const EPS = 1e-5
@@ -21,11 +22,14 @@ export default function usePointland(store, root) {
     const space = layerspace.space
     root.$layerspace = layerspace
     setTimeout(() => store.commit('snack', { message: 'Welcome to Pointland' }), 1000)
-    space.potree.loadPointCloud('cloud.js', (url) => `https://storage.googleapis.com/tokyo-potree/${url}`).then((pco) => loadPCO(pco, space))
+    space.potree
+      .loadPointCloud('cloud.js', (url) => `https://storage.googleapis.com/tokyo-potree/${url}`)
+      .then((pco) => loadPCO(pco, layerspace))
     return layerspace
   }
 
-  function loadPCO(pco, space) {
+  function loadPCO(pco, layerspace) {
+    const space = layerspace.space
     store.commit('setLoading', false)
     space.offset = [pco.position.x, pco.position.y, pco.position.z]
     pco.translateX(-pco.position.x)
@@ -47,6 +51,10 @@ export default function usePointland(store, root) {
     pco.material.rgbBrightness = 0.05
     pco.material.rgbContrast = 0.25
     space.controls.setTarget(POSITION[0] + 7 * EPS, POSITION[1] - 1 * EPS, POSITION[2] - EPS, true)
+    const layer = layerspace.ref.landmarks
+    if (layer)
+      for (const lm of landmarks)
+        layerspace.drawXYZ(layer, lm.position, lm.name)
     // setTimeout(() => store.commit('snack', { message: 'Click Top Left Button for Help', timeout: 10000 }), 10000)
   }
 

--- a/src/data/landmarks.js
+++ b/src/data/landmarks.js
@@ -1,0 +1,7 @@
+export default [
+  { name: 'Tokyo Tower', position: [-12000, -33000, 150] },
+  { name: 'Tokyo Skytree', position: [-8000, -31000, 150] },
+  { name: 'Shibuya Crossing', position: [-10000, -30000, 150] },
+  { name: 'Shinjuku Station', position: [-13000, -29000, 150] },
+  { name: 'Tokyo Station', position: [-9000, -32000, 150] },
+]

--- a/src/pages/index.vue
+++ b/src/pages/index.vue
@@ -4,6 +4,7 @@
       <point-land class="wrapper" />
     </client-only>
     <help-btn />
+    <landmark-btns />
     <div class="source-info">
       This pointcloud source is from
       <a href="https://3dview.tokyo-digitaltwin.metro.tokyo.lg.jp/" target="_blank" rel="noopener noreferrer">City of Tokyo</a>
@@ -15,7 +16,8 @@
 </template>
 
 <script lang="ts">
-export default {}
+import LandmarkBtns from '~/components/LandmarkBtns.vue'
+export default { components: { LandmarkBtns } }
 </script>
 
 <style src="~/assets/style/index.css" />

--- a/src/plugins/init/config.js
+++ b/src/plugins/init/config.js
@@ -12,7 +12,11 @@ export default ({ $axios }) => {
       meta: { version: undefined },
       spaceOpt: {
         id: 'pointland',
-        layers: { point: [] },
+        layers: {
+          point: [
+            { name: 'landmarks', color: '#ffffff', size: 30, threshold: 2 },
+          ],
+        },
         box: 'skybox',
         position: [10, 130, 50],
       },


### PR DESCRIPTION
## Summary
- add placeholder data for 5 Tokyo landmarks
- draw landmark points when point cloud loads
- expose landmark buttons in the main page
- map F1~F5 keys to jump to landmarks

## Testing
- `yarn lint` *(fails: This package doesn't seem to be present in your lockfile)*

------
https://chatgpt.com/codex/tasks/task_e_6844d58a281c8327a5e6ed03d1fce615