### PR TITLE
feat: persist camera position in localStorage

### DIFF
--- a/src/hooks/usePointland.ts
+++ b/src/hooks/usePointland.ts
@@ -84,21 +84,25 @@ export const usePointland = () => {
 
     const savedCamera = getStoredCamera()
     console.log('Restoring camera:', savedCamera)
-    if (savedCamera.position && savedCamera.target) {
-      console.log('Using saved position')
-      space.controls.setLookAt(
-        savedCamera.position[0],
-        savedCamera.position[1],
-        savedCamera.position[2],
-        savedCamera.target[0],
-        savedCamera.target[1],
-        savedCamera.target[2],
-        false,
-      )
-    } else {
-      console.log('Using default position')
-      space.controls.setLookAt(POSITION[0], POSITION[1], POSITION[2], TARGET[0], TARGET[1], TARGET[2], true)
-    }
+
+    // Use requestAnimationFrame to ensure controls are ready
+    requestAnimationFrame(() => {
+      if (savedCamera.position && savedCamera.target) {
+        console.log('Using saved position')
+        space.controls.setLookAt(
+          savedCamera.position[0],
+          savedCamera.position[1],
+          savedCamera.position[2],
+          savedCamera.target[0],
+          savedCamera.target[1],
+          savedCamera.target[2],
+          false,
+        )
+      } else {
+        console.log('Using default position')
+        space.controls.setLookAt(POSITION[0], POSITION[1], POSITION[2], TARGET[0], TARGET[1], TARGET[2], false)
+      }
+    })
 
     let saveTimeout: ReturnType<typeof setTimeout> | null = null
     const handleControlUpdate = () => {
@@ -121,11 +125,15 @@ export const usePointland = () => {
 
       setLoading(true)
 
+      // Get saved camera position before LayerSpace initialization
+      const savedCamera = getStoredCamera()
+      const initialPosition = savedCamera.position ?? POSITION
+
       const spaceOpt: SpaceOptions = {
         id: 'pointland',
         layers: { point: [] },
         box: 'skybox',
-        position: POSITION,
+        position: initialPosition,
         callback: {
           click: (...args) => {
             console.debug(args)

--- a/src/hooks/usePointland.ts
+++ b/src/hooks/usePointland.ts
@@ -83,7 +83,9 @@ export const usePointland = () => {
     pco.material.rgbContrast = 0.25
 
     const savedCamera = getStoredCamera()
+    console.log('Restoring camera:', savedCamera)
     if (savedCamera.position && savedCamera.target) {
+      console.log('Using saved position')
       space.controls.setLookAt(
         savedCamera.position[0],
         savedCamera.position[1],
@@ -94,6 +96,7 @@ export const usePointland = () => {
         false,
       )
     } else {
+      console.log('Using default position')
       space.controls.setLookAt(POSITION[0], POSITION[1], POSITION[2], TARGET[0], TARGET[1], TARGET[2], true)
     }
 
@@ -103,6 +106,7 @@ export const usePointland = () => {
       saveTimeout = setTimeout(() => {
         const pos = space.controls.getPosition()
         const target = space.controls.getTarget()
+        console.log('Saving camera:', { position: [pos.x, pos.y, pos.z], target: [target.x, target.y, target.z] })
         saveCamera([pos.x, pos.y, pos.z], [target.x, target.y, target.z])
       }, 500)
     }

--- a/src/hooks/usePointland.ts
+++ b/src/hooks/usePointland.ts
@@ -94,7 +94,7 @@ export const usePointland = () => {
         false,
       )
     } else {
-      space.controls.setTarget(TARGET[0], TARGET[1], TARGET[2], true)
+      space.controls.setLookAt(POSITION[0], POSITION[1], POSITION[2], TARGET[0], TARGET[1], TARGET[2], true)
     }
 
     let saveTimeout: ReturnType<typeof setTimeout> | null = null

--- a/src/store/ls.ts
+++ b/src/store/ls.ts
@@ -10,10 +10,15 @@ export interface CameraState {
 }
 
 export const getStoredCamera = (): CameraState => {
+  if (typeof window === 'undefined') {
+    return { position: null, target: null }
+  }
   try {
     const stored = localStorage.getItem(STORAGE_KEY)
     if (stored) {
-      return JSON.parse(stored)
+      const parsed = JSON.parse(stored)
+      console.log('Retrieved from localStorage:', parsed)
+      return parsed
     }
   } catch (e) {
     console.warn('Failed to parse stored camera state:', e)
@@ -22,8 +27,11 @@ export const getStoredCamera = (): CameraState => {
 }
 
 export const saveCamera = (position: [number, number, number], target: [number, number, number]): void => {
+  if (typeof window === 'undefined') return
   try {
-    localStorage.setItem(STORAGE_KEY, JSON.stringify({ position, target }))
+    const data = { position, target }
+    console.log('Saving to localStorage:', data)
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(data))
   } catch (e) {
     console.warn('Failed to save camera state:', e)
   }

--- a/src/store/ls.ts
+++ b/src/store/ls.ts
@@ -1,11 +1,38 @@
 /*
- * @summary - Local Storage Module
+ * @summary - Local Storage Module for Camera Position
  */
 
-type LSState = Record<string, never>
+const STORAGE_KEY = 'pointland-camera'
 
-export const state = (): LSState => ({})
+export interface CameraState {
+  position: [number, number, number] | null
+  target: [number, number, number] | null
+}
 
-export const mutations = {
-  // Add mutations here as needed
+export const getStoredCamera = (): CameraState => {
+  try {
+    const stored = localStorage.getItem(STORAGE_KEY)
+    if (stored) {
+      return JSON.parse(stored)
+    }
+  } catch (e) {
+    console.warn('Failed to parse stored camera state:', e)
+  }
+  return { position: null, target: null }
+}
+
+export const saveCamera = (position: [number, number, number], target: [number, number, number]): void => {
+  try {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify({ position, target }))
+  } catch (e) {
+    console.warn('Failed to save camera state:', e)
+  }
+}
+
+export const clearStoredCamera = (): void => {
+  try {
+    localStorage.removeItem(STORAGE_KEY)
+  } catch (e) {
+    console.warn('Failed to clear camera state:', e)
+  }
 }


### PR DESCRIPTION
## Summary
- Save camera position and target to localStorage on control updates
- Restore saved camera position on page load
- Debounced saving (500ms) to avoid excessive writes
- Export DEFAULT_CAMERA constant for future reset functionality

## How it works
1. On page load, checks localStorage for saved camera state
2. If found, restores camera to saved position/target
3. On every camera movement, saves position after 500ms debounce
4. Falls back to default initial view if no saved state

## Test plan
- [ ] Navigate camera to a specific location
- [ ] Refresh the page
- [ ] Verify camera returns to saved location
- [ ] Clear localStorage and verify default view loads

🤖 Generated with [Claude Code](https://claude.com/claude-code)